### PR TITLE
docs: Update default port from 8000 to 6336 in documentation and exam…

### DIFF
--- a/calibre_api/AGENTS.md
+++ b/calibre_api/AGENTS.md
@@ -36,13 +36,13 @@ This document provides instructions for AI agents working on the `calibre_api` p
 4.  **Running the FastAPI Application**:
     From the `calibre_api` root directory, run the Uvicorn server:
     ```bash
-    python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+    python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 6336
     ```
     *   `app.main:app` refers to the `app` instance of `FastAPI` in `calibre_api/app/main.py`.
     *   `--reload` enables auto-reloading on code changes (for development).
-    *   The API will be accessible at `http://localhost:8000`.
-    *   Interactive API documentation (Swagger UI) will be at `http://localhost:8000/docs`.
-    *   Alternative API documentation (ReDoc) will be at `http://localhost:8000/redoc`.
+    *   The API will be accessible at `http://localhost:6336`.
+    *   Interactive API documentation (Swagger UI) will be at `http://localhost:6336/docs`.
+    *   Alternative API documentation (ReDoc) will be at `http://localhost:6336/redoc`.
 
 ### Testing
 
@@ -66,7 +66,7 @@ This document provides instructions for AI agents working on the `calibre_api` p
 
 *   **Default Library**: If `calibredb` is configured with a default library, the API will use it when no `library_path` is specified.
 *   **Specific Library**: To target a specific Calibre library, use the `library_path` query parameter with the API endpoints.
-    *   Example: `GET http://localhost:8000/books/?library_path=/path/to/your/calibre/library`
+    *   Example: `GET http://localhost:6336/books/?library_path=/path/to/your/calibre/library`
 *   **For Manual Testing**:
     *   Ensure you have a Calibre library populated with some books.
     *   You can create one using the Calibre desktop application.

--- a/calibre_api/README.md
+++ b/calibre_api/README.md
@@ -39,12 +39,12 @@ A Python FastAPI application that provides a RESTful API wrapper for the `calibr
 Once the setup is complete, you can run the FastAPI application using Uvicorn:
 
 ```bash
-python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 6336
 ```
 
-*   The API will be available at `http://localhost:8000`.
-*   Interactive API documentation (Swagger UI) can be accessed at `http://localhost:8000/docs`.
-*   Alternative API documentation (ReDoc) can be accessed at `http://localhost:8000/redoc`.
+*   The API will be available at `http://localhost:6336`.
+*   Interactive API documentation (Swagger UI) can be accessed at `http://localhost:6336/docs`.
+*   Alternative API documentation (ReDoc) can be accessed at `http://localhost:6336/redoc`.
 
 ## API Endpoints
 

--- a/calibre_api/app/main.py
+++ b/calibre_api/app/main.py
@@ -100,12 +100,12 @@ async def get_books_endpoint(
         )
 
 # Example of how to run for local development:
-# uvicorn calibre_api.app.main:app --reload --port 8000
-# or python -m uvicorn calibre_api.app.main:app --reload --port 8000
+# uvicorn calibre_api.app.main:app --reload --port 6336
+# or python -m uvicorn calibre_api.app.main:app --reload --port 6336
 # Ensure calibredb is in PATH and you have a calibre library.
 # Test with:
-# http://localhost:8000/books/
-# http://localhost:8000/books/?search=science%20fiction
-# http://localhost:8000/books/?library_path=/path/to/your/calibre/library
-# http://localhost:8000/docs for Swagger UI
-# http://localhost:8000/redoc for ReDoc UI
+# http://localhost:6336/books/
+# http://localhost:6336/books/?search=science%20fiction
+# http://localhost:6336/books/?library_path=/path/to/your/calibre/library
+# http://localhost:6336/docs for Swagger UI
+# http://localhost:6336/redoc for ReDoc UI


### PR DESCRIPTION
…ples

This commit updates the port number in AGENTS.md, README.md, and example comments in main.py to use 6336 instead of 8000, as per your request.