### PR TITLE
I've renamed the project to Shelfstone and updated the component name…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Calibre Web Application
+# Shelfstone
 
 ## Overview
 
 This project provides a containerized web application for interacting with a Calibre e-book library. It consists of:
 
-*   A **backend API** (built with FastAPI and Python) that uses Calibre's command-line tools (`calibredb`, `ebook-convert`, etc.) to manage and access e-book data.
-*   A **frontend web interface** (built with SvelteKit) that communicates with the backend API to provide a user-friendly experience.
+*   A **Shelfstone Server** (built with FastAPI and Python) that uses Calibre's command-line tools (`calibredb`, `ebook-convert`, etc.) to manage and access e-book data.
+*   A **Shelfstone Web** (built with SvelteKit) that communicates with the backend API to provide a user-friendly experience.
 
 The entire application is designed to be run using Docker and Docker Compose, simplifying setup and deployment.
 
@@ -77,14 +77,14 @@ This command will stop the containers. If you also want to remove the volumes (t
 
 *   **Viewing Logs:** To see the logs from the running containers (useful for troubleshooting):
     ```bash
-    docker-compose logs -f backend
-    docker-compose logs -f frontend
+    docker-compose logs -f shelfstone-server
+    docker-compose logs -f shelfstone-web
     # To see logs for all services:
     docker-compose logs -f
     ```
     Press `Ctrl+C` to stop tailing the logs.
 
-*   **Rebuilding Images:** If you make changes to the application code (backend or frontend) or the Dockerfiles, you'll need to rebuild the Docker images:
+*   **Rebuilding Images:** If you make changes to the application code (Shelfstone Server or Shelfstone Web) or the Dockerfiles, you'll need to rebuild the Docker images:
     ```bash
     docker-compose up -d --build
     ```
@@ -92,7 +92,7 @@ This command will stop the containers. If you also want to remove the volumes (t
 ## Troubleshooting
 
 *   **Port Conflicts:** If ports `6464` or `8001` are already in use on your system, you can change them in the `docker-compose.yml` file (the host-side port mapping, e.g., `"NEW_PORT:6336"`).
-*   **Calibre Issues:** If the backend has issues related to Calibre itself, check the logs of the `backend` service. Ensure Calibre is correctly installed in the Docker image (this should be handled by the `calibre_api/Dockerfile`).
-*   **Frontend Build Issues:** If the frontend fails to build, check the logs during the `docker-compose up --build` process. It might indicate missing dependencies or build script errors.
+*   **Calibre Issues:** If the Shelfstone Server has issues related to Calibre itself, check the logs of the `shelfstone-server` service. Ensure Calibre is correctly installed in the Docker image (this should be handled by the `calibre_api/Dockerfile`).
+*   **Frontend Build Issues:** If Shelfstone Web fails to build, check the logs during the `docker-compose up --build` process. It might indicate missing dependencies or build script errors.
 
 This `README.md` should provide a good starting point for users.

--- a/calibre_api/api_endpoints.md
+++ b/calibre_api/api_endpoints.md
@@ -1,6 +1,6 @@
-# Calibre API Endpoints
+# Shelfstone Server API Endpoints
 
-This document lists the available API endpoints for the Calibre API.
+This document lists the available API endpoints for the Shelfstone Server API.
 
 ## Endpoints
 
@@ -384,7 +384,7 @@ These endpoints provide access to various general-purpose Calibre command-line t
         {
           "recipient_email": "test@example.com",
           "subject": "API Test Email",
-          "body": "Hello from the Calibre API!",
+          "body": "Hello from the Shelfstone Server API!",
           "smtp_server": "smtp.mailprovider.com",
           "smtp_port": 587,
           "smtp_username": "user@example.com",

--- a/calibre_api/app/main.py
+++ b/calibre_api/app/main.py
@@ -13,8 +13,8 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI(
-    title="CalibreDB API",
-    description="A FastAPI wrapper for the calibredb command-line tool.",
+    title="Shelfstone Server API",
+    description="A FastAPI wrapper for Calibre command-line tools, providing the backend for Shelfstone.",
     version="0.1.0",
 )
 
@@ -359,7 +359,7 @@ from fastapi.responses import StreamingResponse
 from io import BytesIO
 
 # Helper to create a unique temporary file path
-def temp_file_path(prefix: str = "calibre_api_", suffix: str = "") -> str:
+def temp_file_path(prefix: str = "shelfstone_server_", suffix: str = "") -> str:
     return os.path.join(tempfile.gettempdir(), f"{prefix}{uuid.uuid4()}{suffix}")
 
 

--- a/calibre_api/shelfstone_server_README.md
+++ b/calibre_api/shelfstone_server_README.md
@@ -1,6 +1,6 @@
-# Calibre API
+# Shelfstone Server
 
-A Python FastAPI application that provides a RESTful API wrapper for various Calibre command-line tools, allowing you to manage e-book libraries, convert formats, edit metadata, and perform other Calibre functions programmatically.
+A Python FastAPI application that provides a RESTful API wrapper for various Calibre command-line tools, allowing you to manage e-book libraries, convert formats, edit metadata, and perform other Calibre functions programmatically. This server acts as the backend for the Shelfstone project.
 
 -----
 
@@ -45,7 +45,7 @@ A Python FastAPI application that provides a RESTful API wrapper for various Cal
 
     ```bash
     git clone https://github.com/mjryan253/shelfstone-gnu.git
-    cd calibre_api
+    cd shelfstone-gnu/calibre_api
     ```
 
 2.  **Create and Activate a Virtual Environment** (recommended):
@@ -65,14 +65,14 @@ A Python FastAPI application that provides a RESTful API wrapper for various Cal
 
 ## Running the Application
 
-Once the setup is complete, you can run the FastAPI application using Uvicorn:
+Once the setup is complete, you can run the FastAPI application using Uvicorn (ensure you are in the `calibre_api` directory):
 
 ```bash
 python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 6336
 ```
 
-The API will be available at `http://localhost:6336`.
-Interactive API documentation (Swagger UI) can be accessed at `http://localhost:6336/docs`.
+The Shelfstone Server API will be available at `http://localhost:6336` (internally) and typically accessed via the main application's Nginx proxy (e.g., `http://localhost:6464/api/`).
+Interactive API documentation (Swagger UI) for the direct service can be accessed at `http://localhost:6336/docs`.
 Alternative API documentation (ReDoc) can be accessed at `http://localhost:6336/redoc`.
 
 -----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3.8'
 
 services:
-  backend:
+  shelfstone-server:
     build:
       context: ./calibre_api
       dockerfile: Dockerfile
     ports:
-      - "8001:6336" # Exposes backend on host port 8001, container port 6336
+      - "8001:6336" # Exposes Shelfstone Server on host port 8001, container port 6336
     volumes:
       # Optional: Mount a volume for Calibre library persistence.
       # Create a directory e.g., './calibre_library_data' on your host machine first.
@@ -30,14 +30,14 @@ services:
     #   start_period: 30s # Give Calibre time to initialize if needed
     restart: unless-stopped
 
-  frontend:
+  shelfstone-web:
     build:
       context: ./web
       dockerfile: Dockerfile
     ports:
-      - "6464:80" # Exposes frontend on host port 6464, container port 80 (Nginx)
+      - "6464:80" # Exposes Shelfstone Web on host port 6464, container port 80 (Nginx)
     depends_on:
-      - backend # Ensures backend is started before frontend, good for initial API calls
+      - shelfstone-server # Ensures server is started before web, good for initial API calls
     # healthcheck: # Nginx usually starts quickly
     #   test: ["CMD", "curl", "-f", "http://localhost:80"]
     #   interval: 30s

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -18,7 +18,7 @@ server {
 
     # Handle API requests by proxying to the backend service
     location /api/ {
-        proxy_pass http://backend:6336/; # Forward to the backend service named 'backend' on port 6336
+        proxy_pass http://shelfstone-server:6336/; # Forward to the Shelfstone Server service on port 6336
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web-frontend",
+  "name": "shelfstone-web",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -3,8 +3,8 @@
   import EpubRenderer from '$lib/components/EpubRenderer.svelte';
   import LibraryView from '$lib/components/LibraryView.svelte';
 
-  // Base URL for the API
-  const API_BASE_URL = 'http://localhost:6336';
+  // Base URL for the API - relative path to use Nginx proxy
+  const API_BASE_URL = '/api';
 
   let currentEpubData: ArrayBuffer | null = null;
   let currentBookId: number | null = null;
@@ -42,12 +42,12 @@
 </script>
 
 <svelte:head>
-  <title>ShelfStone - ePub Reader & Library</title>
+  <title>Shelfstone - ePub Reader & Library</title>
 </svelte:head>
 
 <div class="app-container">
   <header class="app-header">
-    <h1>ShelfStone</h1>
+    <h1>Shelfstone</h1>
   </header>
 
   <main class="main-content">


### PR DESCRIPTION
…s for you.

- Changed project name to 'Shelfstone'.
- Renamed frontend to 'shelfstone-web'.
- Renamed backend to 'shelfstone-server' in documentation and service names.
- Updated docker-compose services, Nginx proxy, and relevant READMEs.
- Kept backend directory as 'calibre_api/' due to some limitations I encountered with directory renaming, but updated its internal README name.
- Ensured API calls from frontend are correctly routed.