### PR TITLE
Fix: Resolve merge conflict in +layout.js

### DIFF
--- a/web/src/routes/+layout.js
+++ b/web/src/routes/+layout.js
@@ -1,5 +1,1 @@
-<<<<<<< Updated upstream
 export const prerender = true;
-=======
-export const prerender = true;
->>>>>>> Stashed changes


### PR DESCRIPTION
Resolved a merge conflict in `web/src/routes/+layout.js` that was causing the Docker build to fail. Removed conflict markers and a duplicated line.