### PR TITLE
Fix: Update frontend API calls to correct port and book download path

### DIFF
--- a/web-nextjs/src/app/books/[id]/edit/page.tsx
+++ b/web-nextjs/src/app/books/[id]/edit/page.tsx
@@ -70,7 +70,7 @@ export default function EditBookPage({ params }: EditBookPageProps) {
       setLoading(true);
       try {
         // Fetch existing book data to prefill the form
-        const response = await fetch(`http://localhost:8001/books/?search=ids:${id}`);
+        const response = await fetch(`http://localhost:6336/books/?search=ids:${id}`);
         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
         const data: Book[] = await response.json();
         if (data.length > 0) {
@@ -167,7 +167,7 @@ export default function EditBookPage({ params }: EditBookPageProps) {
 
 
     try {
-      const response = await fetch(`http://localhost:8001/books/${book.id}/metadata/`, {
+      const response = await fetch(`http://localhost:6336/books/${book.id}/metadata/`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/web-nextjs/src/app/books/[id]/page.tsx
+++ b/web-nextjs/src/app/books/[id]/page.tsx
@@ -63,7 +63,7 @@ export default function BookDetailsPage({ params }: BookDetailsPageProps) {
         // Example: `search=id:123`. This needs to be tested if `calibredb list` supports `id:` prefix.
         // Calibre's search syntax is powerful, `ids:123` or `id:123` might work.
         // Let's try with `search=ids:${id}` as `ids` is a common Calibre search field.
-        const response = await fetch(`http://localhost:8001/books/?search=ids:${id}`);
+        const response = await fetch(`http://localhost:6336/books/?search=ids:${id}`);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
@@ -91,7 +91,7 @@ export default function BookDetailsPage({ params }: BookDetailsPageProps) {
     if (!book) return;
     if (window.confirm(`Are you sure you want to delete "${book.title}"?`)) {
       try {
-        const response = await fetch(`http://localhost:8001/books/${book.id}/`, {
+        const response = await fetch(`http://localhost:6336/books/${book.id}/`, {
           method: 'DELETE',
         });
         if (!response.ok) {

--- a/web-nextjs/src/app/library/page.tsx
+++ b/web-nextjs/src/app/library/page.tsx
@@ -45,7 +45,7 @@ export default function LibraryPage() {
         // The API supports a `search` query parameter.
         // For now, we fetch all and filter/sort client-side.
         // Later, we can implement server-side search by passing `searchTerm` to this URL.
-        const apiUrl = `http://localhost:8001/books/`;
+        const apiUrl = `http://localhost:6336/books/`;
         const response = await fetch(apiUrl);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/web-nextjs/src/app/read/[id]/page.tsx
+++ b/web-nextjs/src/app/read/[id]/page.tsx
@@ -32,7 +32,7 @@ export default function ReadPage({ params }: ReadPageProps) {
       setLoading(true);
       try {
         // Fetch book metadata to get title and available formats
-        const response = await fetch(`http://localhost:8001/books/?search=ids:${id}`);
+        const response = await fetch(`http://localhost:6336/books/?search=ids:${id}`);
         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
         const data: Book[] = await response.json();
 
@@ -40,15 +40,11 @@ export default function ReadPage({ params }: ReadPageProps) {
           const fetchedBook = data[0];
           setBook(fetchedBook);
 
-          // Construct a *hypothetical* URL to the EPUB file.
-          // THIS WILL LIKELY NOT WORK without a backend endpoint that serves book files.
-          // Example: http://localhost:8001/books/{id}/download?format=epub
-          // For now, we'll check if EPUB is listed in formats and make a guess.
+          // Construct the URL to the EPUB file using the backend endpoint.
           const formats = fetchedBook.formats?.toLowerCase().split(',') || [];
           if (formats.includes('epub')) {
-            // THIS IS A PLACEHOLDER URL
-            setBookFileUrl(`http://localhost:8001/books/${fetchedBook.id}/download?format=epub`);
-             setError("Note: The book URL is a placeholder and likely won't load the book. A backend endpoint to serve book files is required.");
+            setBookFileUrl(`http://localhost:6336/books/${fetchedBook.id}/file/epub`);
+            setError(null); // Clear any previous error message
           } else {
             setError("EPUB format not found for this book. Other formats are not yet supported by this viewer.");
           }

--- a/web-nextjs/src/app/upload/page.tsx
+++ b/web-nextjs/src/app/upload/page.tsx
@@ -38,7 +38,7 @@ export default function UploadPage() {
     // Add other optional parameters from API docs as needed, e.g., library_path, duplicates, automerge
 
     try {
-      const response = await fetch('http://localhost:8001/books/add/', {
+      const response = await fetch('http://localhost:6336/books/add/', {
         method: 'POST',
         body: formData,
         // Headers are not typically needed for FormData; browser sets Content-Type to multipart/form-data


### PR DESCRIPTION
- I changed the API endpoint port from 8001 to 6336 in all frontend components.
- I updated the book reading page to use the correct backend endpoint GET /books/{book_id}/file/{format_extension} for downloading book files.