### PR TITLE
I've addressed the Docker build issues and a TypeScript error. Here's…

### DIFF
--- a/calibre_api/Dockerfile
+++ b/calibre_api/Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get update && apt-get install -y \
     libegl1 \
     libxcb-cursor0 \
     libopengl0 \
+    build-essential \
+    gcc \
+    libc6-dev \
     # Add any other specific dependencies Calibre might need on a slim image
  && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin \
  && apt-get clean \

--- a/web-nextjs/Dockerfile
+++ b/web-nextjs/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 # Copy package.json and lock file
 COPY package.json ./
 # COPY pnpm-lock.yaml ./  # If using pnpm
-COPY package-lock.json* ./ # If using npm or if package-lock.json exists
+COPY package-lock.json ./ # If using npm or if package-lock.json exists
 
 # Install dependencies
 # RUN pnpm install --frozen-lockfile # If using pnpm

--- a/web-nextjs/src/app/books/[id]/edit/page.tsx
+++ b/web-nextjs/src/app/books/[id]/edit/page.tsx
@@ -53,7 +53,7 @@ const authorsToStringForForm = (authorsStr?: string): string => {
 };
 
 
-export default function EditBookPage({ params }: EditBookPageProps) {
+export default function EditBookPage({ params }: { params: { id: string } }) {
   const { id } = params;
   const router = useRouter();
   const [book, setBook] = useState<Book | null>(null);


### PR DESCRIPTION
… a summary of the changes:

- I modified `web-nextjs/Dockerfile` to fix a file copy error during the build process.
- I added build-essential dependencies to `calibre_api/Dockerfile` to resolve a CGO-related runtime error with Calibre.
- I corrected a TypeScript type definition in `web-nextjs/src/app/books/[id]/edit/page.tsx` that was causing the Next.js build to fail.